### PR TITLE
Deploy: OAuth redirect URL 환경별 분기 처리

### DIFF
--- a/app/(auth)/kakaologin/_components/KakaoLoginButton.tsx
+++ b/app/(auth)/kakaologin/_components/KakaoLoginButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { createClient } from '@/lib/supabase/client';
+import { getURL } from '@/lib/utils';
 
 function KakaoSpeechBubbleMark({ className }: { className?: string }) {
   return (
@@ -20,7 +21,7 @@ export default function KakaoLoginButton() {
     await supabase.auth.signInWithOAuth({
       provider: 'kakao',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${getURL()}auth/callback`,
       },
     });
   };

--- a/app/auth/auth-code-error/page.tsx
+++ b/app/auth/auth-code-error/page.tsx
@@ -1,0 +1,11 @@
+export default function AuthCodeErrorPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-noto-subtitle-1 mb-4">로그인 중 오류가 발생했습니다</h1>
+      <p className="mb-4">다시 시도해주세요.</p>
+      <a href="/" className="text-blue-500 underline">
+        홈으로 돌아가기
+      </a>
+    </div>
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const getURL = () => {
+  let url =
+    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
+    'http://localhost:3000/';
+  url = url.startsWith('http') ? url : `https://${url}`;
+  url = url.endsWith('/') ? url : `${url}/`;
+  return url;
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,11 +6,10 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const getURL = () => {
-  let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ??
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ??
-    'http://localhost:3000/';
-  url = url.startsWith('http') ? url : `https://${url}`;
+  if (typeof window !== 'undefined') {
+    return window.location.origin + '/';
+  }
+  let url = process?.env?.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000/';
   url = url.endsWith('/') ? url : `${url}/`;
   return url;
 };


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명-->

Production 배포를 위한 OAuth 로그인 환경 분기 처리 및 에러 핸들링 페이지 추가

### 변경 사항

- **OAuth Redirect URL 동적 분기 처리**
  - 기존: 로그인 후 항상 `localhost:3000`으로 리다이렉트되는 문제
  - 변경: `getURL()` 헬퍼 함수를 통해 환경별 자동 분기
    - 클라이언트: `window.location.origin` 사용
    - 서버: 환경변수 fallback (`NEXT_PUBLIC_SITE_URL` → `localhost`)
  - 이제 로컬/Preview/Production 각 환경에서 올바른 URL로 리다이렉트됨

- **OAuth 에러 페이지 추가**
  - `/auth/auth-code-error` 라우트 404 발생 문제 해결
  - 로그인 실패 시 안내 페이지 표시

### 관련 환경 설정 (PR 외 사전 작업 완료)

- [x] Vercel: `NEXT_PUBLIC_SITE_URL` Production 환경변수 등록
- [x] Supabase: Site URL 및 Redirect URLs 등록
  - `http://localhost:3000/**`
  - `https://pangea-dev.vercel.app/**`
  - `https://*-haeyeon-kims-projects-347134bd.vercel.app/**`

## 리뷰 요청 사항
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

1. **`getURL()` 헬퍼 함수 로직**
   - 클라이언트/서버 분기가 적절한지
   - SSR 환경에서도 의도대로 동작하는지

2. **`signInWithOAuth` 호출부**
   - `redirectTo` 옵션의 경로(`/auth/callback`)가 실제 콜백 라우트와 일치하는지

3. **에러 페이지 디자인**
   - 프로젝트의 다른 페이지와 톤이 맞는지
   - 사용자에게 보여줄 안내 문구가 적절한지

## 테스트 완료

- [x] Preview 배포(`feat/#39-redirect-url`)에서 카카오 로그인 정상 동작 확인
- [x] 로그인 후 Preview URL로 정상 리다이렉트 확인
- [ ] Production 머지 후 `pangea-dev.vercel.app`에서 최종 검증 예정