### PR TITLE
feat: drawer에서 feed, explore 주석 처리 (#42)

### DIFF
--- a/components/HeaderMenuDrawer.tsx
+++ b/components/HeaderMenuDrawer.tsx
@@ -9,8 +9,8 @@ import { createClient } from '@/lib/supabase/client';
 
 const MENU_ITEMS = [
   { href: PATH.CART, label: '담아둔 것들', requiresAuth: true },
-  { href: PATH.FEED, label: '나의 대륙', requiresAuth: false },
-  { href: PATH.EXPLORE, label: '탐험', requiresAuth: false },
+  // { href: PATH.FEED, label: '나의 대륙', requiresAuth: false },
+  // { href: PATH.EXPLORE, label: '탐험', requiresAuth: false },
 ] as const;
 
 export default function HeaderMenuDrawer() {


### PR DESCRIPTION
close issue #42 

## Summary
- HeaderMenuDrawer의 메뉴 항목 중 '나의 대륙'(FEED)과 '탐험'(EXPLORE) 항목을 주석 처리하여 임시로 비활성화

## Test plan
- [ ] 드로어를 열었을 때 '담아둔 것들' 항목만 노출되는지 확인
- [ ] FEED, EXPLORE 메뉴가 더 이상 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)