### PR TITLE
fix: 주문 완료 페이지 및 피드 업로드 텍스트 수정 (#56)

### DIFF
--- a/app/(with-header)/feed/upload/_components/FeedUploadFlow.tsx
+++ b/app/(with-header)/feed/upload/_components/FeedUploadFlow.tsx
@@ -13,6 +13,9 @@ import StepImageUpload from './StepImageUpload';
 import StepIndicator from './StepIndicator';
 import StepQuestionAnswer from './StepQuestionAnswer';
 
+// 1차 배포 후 false로 변경
+const IS_BEFORE_BOOK_ARRIVAL = true;
+
 type Step = 1 | 2 | 3;
 type Question = BookWithQuestions['questions'][number];
 
@@ -177,7 +180,7 @@ export default function FeedUploadFlow({ books }: Props) {
   const questions = selectedBook?.questions ?? [];
 
   const isNextDisabled =
-    (currentStep === 1 && selectedBook === null) ||
+    (currentStep === 1 && (selectedBook === null || IS_BEFORE_BOOK_ARRIVAL)) ||
     (currentStep === 2 && images.length === 0) ||
     (currentStep === 3 &&
       (selectedQuestion === null || answer.trim().length === 0 || isSubmitting));
@@ -236,6 +239,14 @@ export default function FeedUploadFlow({ books }: Props) {
             />
           ) : null}
         </div>
+
+        {currentStep === 1 && IS_BEFORE_BOOK_ARRIVAL && selectedBook !== null && (
+          <div className="rounded-none border border-primary/30 bg-primary/5 p-4">
+            <p className="text-pretendard-body-2 text-primary">
+              아직 첫 번째 책이 도착하기 전입니다.
+            </p>
+          </div>
+        )}
 
         <StepFooter
           showBack={currentStep > 1}

--- a/app/(with-header)/feed/upload/_components/StepBookSelect.tsx
+++ b/app/(with-header)/feed/upload/_components/StepBookSelect.tsx
@@ -15,8 +15,7 @@ export default function StepBookSelect({ books, selectedBook, onSelect }: Props)
       <div className="flex flex-col gap-1">
         <h2 className="text-noto-subtitle-1">어떤 책을 읽으셨나요?</h2>
         <p className="text-pretendard-body-2 whitespace-pre-line text-primary/60">
-          본인이 읽은 책만 선택해주세요. <br /> 선택한 순간, 책의 제목과 정보가 노출됩니다. <br />이
-          경험은 되돌릴 수 없습니다.
+          선택한 순간, 책의 제목과 정보가 노출됩니다. <br />이 경험은 되돌릴 수 없습니다.
         </p>
       </div>
 

--- a/app/(with-header)/order/complete/page.tsx
+++ b/app/(with-header)/order/complete/page.tsx
@@ -45,7 +45,11 @@ export default async function OrderCompletePage({ searchParams }: Props) {
         <SummaryRow label="입금 금액" value={`${order.total_amount.toLocaleString('ko-KR')} 원`} />
         <SummaryRow label="받는 분" value={order.recipient_name} />
         {/* <SummaryRow label="입금 기한" value={paymentDueAt} /> */}
-        <SummaryRow label="입금 기한" value={'5월 19일 (화) 오후 2시까지'} />
+        <SummaryRow label="입금 기한" value={'주문 후 1시간 이내'} />
+        <p className="text-pretendard-caption text-red-800">
+          * 입금 기한 1시간 초과 시 자동 취소됩니다. <br />* 화요일 오후 2시 전 ‘입금’ 완료 건에
+          한하여 이번주 발송됩니다.
+        </p>
       </section>
 
       <section className="mb-section-sm rounded-lg border border-purple3 p-6">


### PR DESCRIPTION
## Summary

- 주문 완료 페이지 입금 기한 텍스트를 고정 날짜에서 '주문 후 1시간 이내'로 변경
- 1시간 초과 자동 취소 및 이번주 발송 조건 안내 문구 추가
- 피드 업로드 책 선택 안내 문구 간소화
- 첫 번째 책 도착 전 피드 업로드 차단 로직(`IS_BEFORE_BOOK_ARRIVAL`) 추가

## Test plan

- [ ] 주문 완료 페이지에서 입금 기한 문구 및 주의사항이 올바르게 표시되는지 확인
- [ ] 피드 업로드 step 1에서 책 선택 후 '아직 첫 번째 책이 도착하기 전입니다' 메시지가 표시되는지 확인
- [ ] `IS_BEFORE_BOOK_ARRIVAL = true` 상태에서 다음 단계로 진행 불가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)